### PR TITLE
商品一覧表示実装

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,18 +2,17 @@ class ApplicationController < ActionController::Base
   before_action :basic_auth
   before_action :configure_permitted_parameters, if: :devise_controller?
 
-
   private
 
   def basic_auth
     authenticate_or_request_with_http_basic do |username, password|
-    # 環境変数を読み込む記述に変更
-      username == ENV["BASIC_AUTH_USER"] && password == ENV["BASIC_AUTH_PASSWORD"]
+      # 環境変数を読み込む記述に変更
+      username == ENV['BASIC_AUTH_USER'] && password == ENV['BASIC_AUTH_PASSWORD']
     end
   end
 
   def configure_permitted_parameters
-    devise_parameter_sanitizer.permit(:sign_up, keys: [:nickname, :first_name, :last_name, :first_name_kana, :last_name_kana, :birthday ])
+    devise_parameter_sanitizer.permit(:sign_up,
+                                      keys: [:nickname, :first_name, :last_name, :first_name_kana, :last_name_kana, :birthday])
   end
-
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,9 +1,8 @@
 class ItemsController < ApplicationController
-
   before_action :authenticate_user!, only: [:new]
 
   def index
-    @items = Item.all.order("created_at DESC")
+    @items = Item.all.order('created_at DESC')
   end
 
   def new
@@ -22,7 +21,7 @@ class ItemsController < ApplicationController
   private
 
   def item_params
-    params.require(:item).permit(:image, :name, :explain, :category_id, :status_id, :postage_id, :prefecture_id, :take_days_id, :price).merge(user_id: current_user.id)
+    params.require(:item).permit(:image, :name, :explain, :category_id, :status_id, :postage_id, :prefecture_id, :take_days_id,
+                                 :price).merge(user_id: current_user.id)
   end
-
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -21,7 +21,6 @@ class ItemsController < ApplicationController
   private
 
   def item_params
-    params.require(:item).permit(:image, :name, :explain, :category_id, :status_id, :postage_id, :prefecture_id, :take_days_id,
-                                 :price).merge(user_id: current_user.id)
+    params.require(:item).permit(:image, :name, :explain, :category_id, :status_id, :postage_id, :prefecture_id, :take_days_id, :price).merge(user_id: current_user.id)
   end
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -3,7 +3,7 @@ class ItemsController < ApplicationController
   before_action :authenticate_user!, only: [:new]
 
   def index
-    @items = Item.all
+    @items = Item.all.order("created_at DESC")
   end
 
   def new

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -2,9 +2,9 @@ class ItemsController < ApplicationController
 
   before_action :authenticate_user!, only: [:new]
 
-  #def index
-    #@items = Item.all
-  #end
+  def index
+    @items = Item.all
+  end
 
   def new
     @item = Item.new

--- a/app/models/buy.rb
+++ b/app/models/buy.rb
@@ -1,0 +1,4 @@
+class Buy < ApplicationRecord
+  belongs_to :item
+  belongs_to :user
+end

--- a/app/models/buy.rb
+++ b/app/models/buy.rb
@@ -1,4 +1,2 @@
 class Buy < ApplicationRecord
-  belongs_to :item
-  belongs_to :user
 end

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -13,8 +13,7 @@ class Category < ActiveHash::Base
     { id: 11, name: 'その他' }
   ]
 
-  #主テーブルitemとのアソシエーション
+  # 主テーブルitemとのアソシエーション
   include ActiveHash::Associations
   has_many :items
-
-  end
+end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -1,12 +1,11 @@
 class Item < ApplicationRecord
-
-  #devise(User)とのアソシエーション
+  # devise(User)とのアソシエーション
   belongs_to :user
 
-  #Active Storageとのアソシエーション
+  # Active Storageとのアソシエーション
   has_one_attached :image
-  
-  #Active Hashとのアソシエーション
+
+  # Active Hashとのアソシエーション
   extend ActiveHash::Associations::ActiveRecordExtensions
   belongs_to :category
   belongs_to :status
@@ -14,11 +13,13 @@ class Item < ApplicationRecord
   belongs_to :prefecture
   belongs_to :take_days
 
-  #バリデーション
+  # バリデーション
   validates :image, :name, :explain, :price, presence: true
-  validates :price, numericality: { only_integer: true, greater_than_or_equal_to: 300, less_than_or_equal_to: 9_999_999, message: "は、半角数字で¥300~¥9,999,999の間で入力して下さい" }
+  validates :price,
+            numericality: { only_integer: true, greater_than_or_equal_to: 300, less_than_or_equal_to: 9_999_999,
+                            message: 'は、半角数字で¥300~¥9,999,999の間で入力して下さい' }
 
-  #Active Hashのバリデーション
-  validates :category_id, :status_id, :postage_id, :prefecture_id, :take_days_id, presence: true, numericality: { other_than: 1 , message: "can't be blank" }
-
+  # Active Hashのバリデーション
+  validates :category_id, :status_id, :postage_id, :prefecture_id, :take_days_id, presence: true,
+                                                                                  numericality: { other_than: 1, message: "can't be blank" }
 end

--- a/app/models/postage.rb
+++ b/app/models/postage.rb
@@ -5,8 +5,7 @@ class Postage < ActiveHash::Base
     { id: 3, name: '送料込み(出品者負担)' }
   ]
 
-  #主テーブルitemとのアソシエーション
+  # 主テーブルitemとのアソシエーション
   include ActiveHash::Associations
   has_many :items
-
-  end
+end

--- a/app/models/prefecture.rb
+++ b/app/models/prefecture.rb
@@ -50,8 +50,7 @@ class Prefecture < ActiveHash::Base
     { id: 48, name: '沖縄県' }
   ]
 
-  #主テーブルitemとのアソシエーション
+  # 主テーブルitemとのアソシエーション
   include ActiveHash::Associations
   has_many :items
-
-  end
+end

--- a/app/models/status.rb
+++ b/app/models/status.rb
@@ -9,8 +9,7 @@ class Status < ActiveHash::Base
     { id: 7, name: '全体的に状態が悪い' }
   ]
 
-  #主テーブルitemとのアソシエーション
+  # 主テーブルitemとのアソシエーション
   include ActiveHash::Associations
   has_many :items
-
-  end
+end

--- a/app/models/take_days.rb
+++ b/app/models/take_days.rb
@@ -6,8 +6,7 @@ class TakeDays < ActiveHash::Base
     { id: 4, name: '4~7日で発送' }
   ]
 
-  #主テーブルitemとのアソシエーション
+  # 主テーブルitemとのアソシエーション
   include ActiveHash::Associations
   has_many :items
-
-  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,13 +6,12 @@ class User < ApplicationRecord
 
   has_many :items
 
-  PASSWORD_REGEX = /\A(?=.*?[a-z])(?=.*?[\d])[a-z\d]+\z/i.freeze
+  PASSWORD_REGEX = /\A(?=.*?[a-z])(?=.*?\d)[a-z\d]+\z/i.freeze
   NAME_REGEX     = /\A[ぁ-んァ-ヶ一-龥々ー]+\z/.freeze
   KANA_REGEX     = /\A[ァ-ヶ一]+\z/.freeze
 
-  validates :password, format: { with: PASSWORD_REGEX , message: 'には英字と数字の両方を含めて設定してください'}
+  validates :password, format: { with: PASSWORD_REGEX, message: 'には英字と数字の両方を含めて設定してください' }
   validates :nickname, :birthday, presence: true
-  validates :first_name, :last_name, presence: true, format: { with: NAME_REGEX , message: 'には全角文字を使用してください'}
-  validates :first_name_kana, :last_name_kana, presence: true, format: { with: KANA_REGEX , message: 'には全角カナを使用してください'}
-
+  validates :first_name, :last_name, presence: true, format: { with: NAME_REGEX, message: 'には全角文字を使用してください' }
+  validates :first_name_kana, :last_name_kana, presence: true, format: { with: KANA_REGEX, message: 'には全角カナを使用してください' }
 end

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -128,15 +128,12 @@
     </div>
     <ul class='item-lists'>
 
-
-
-
-
       <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
+      <% @items.each do |item|%>
       <li class='list'>
         <%= link_to "#" do %>
         <div class='item-img-content'>
-          <%= image_tag ''.image, class: "item-img" %>
+          <%= image_tag item.image, class: "item-img" %>
 
           <%# 商品が売れていればsold outを表示しましょう %>
           <div class='sold-out'>
@@ -147,10 +144,10 @@
         </div>
         <div class='item-info'>
           <h3 class='item-name'>
-            <%= "商品名" %>
+            <%= item.name %>
           </h3>
           <div class='item-price'>
-            <span><%= "販売価格" %>円<br><%= '配送料負担' %></span>
+            <span><%= item.price %>円<br><%= item.postage.name %></span>
             <div class='star-btn'>
               <%= image_tag "star.png", class:"star-icon" %>
               <span class='star-count'>0</span>
@@ -159,6 +156,7 @@
         </div>
         <% end %>
       </li>
+      <% end %>
       <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
 
       <%# 商品がない場合は以下のダミー商品が表示されるようにしましょう %>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -128,58 +128,61 @@
     </div>
     <ul class='item-lists'>
 
-      <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
-      <% @items.each do |item|%>
-      <li class='list'>
-        <%= link_to "#" do %>
-        <div class='item-img-content'>
-          <%= image_tag item.image, class: "item-img" %>
+      <% if @items.present? %>
+        <%# if present?で商品のインスタンス変数itemsになにかしらの値入っている場合、表示される %>
+        <% @items.each do |item| %>
+        <li class='list'>
+          <%= link_to "#" do %>
+          <div class='item-img-content'>
+            <%= image_tag item.image, class: "item-img" %>
 
-          <%# 商品が売れていればsold outを表示しましょう %>
-          <div class='sold-out'>
-            <span>Sold Out!!</span>
+            <%# 商品が売れていればsold outを表示しましょう %>
+            <div class='sold-out'>
+              <span>Sold Out!!</span>
+            </div>
+            <%# //商品が売れていればsold outを表示しましょう %>
+
           </div>
-          <%# //商品が売れていればsold outを表示しましょう %>
-
-        </div>
-        <div class='item-info'>
-          <h3 class='item-name'>
-            <%= item.name %>
-          </h3>
-          <div class='item-price'>
-            <span><%= item.price %>円<br><%= item.postage.name %></span>
-            <div class='star-btn'>
-              <%= image_tag "star.png", class:"star-icon" %>
-              <span class='star-count'>0</span>
+          <div class='item-info'>
+            <h3 class='item-name'>
+              <%= item.name %>
+            </h3>
+            <div class='item-price'>
+              <span><%= item.price %>円<br><%= item.postage.name %></span>
+              <div class='star-btn'>
+                <%= image_tag "star.png", class:"star-icon" %>
+                <span class='star-count'>0</span>
+              </div>
             </div>
           </div>
-        </div>
+          <% end %>
+        </li>
         <% end %>
-      </li>
+        <%# if present?で商品のインスタンス変数itemsになにかしらの値入っている場合、表示される %>
+
+      <% else %>
+
+        <%# if present?...elseで商品のインスタンス変数itemsにに何も入っていない場合は以下のダミー商品が表示される %>
+        <li class='list'>
+          <%= link_to '#' do %>
+          <%= image_tag "https://tech-master.s3.amazonaws.com/uploads/curriculums/images/Rails1-4/sample.jpg", class: "item-img" %>
+          <div class='item-info'>
+            <h3 class='item-name'>
+              商品を出品してね！
+            </h3>
+            <div class='item-price'>
+              <span>99999999円<br>(税込み)</span>
+              <div class='star-btn'>
+                <%= image_tag "star.png", class:"star-icon" %>
+                <span class='star-count'>0</span>
+              </div>
+            </div>
+          </div>
+          <% end %>
+        </li>
+        <%# if present?...elseで商品のインスタンス変数itemsにに何も入っていない場合は以下のダミー商品が表示される %>
       <% end %>
-      <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
 
-      <%# 商品がない場合は以下のダミー商品が表示されるようにしましょう %>
-      <%# 商品がある場合は表示されないようにしましょう %>
-      <li class='list'>
-        <%= link_to '#' do %>
-        <%= image_tag "https://tech-master.s3.amazonaws.com/uploads/curriculums/images/Rails1-4/sample.jpg", class: "item-img" %>
-        <div class='item-info'>
-          <h3 class='item-name'>
-            商品を出品してね！
-          </h3>
-          <div class='item-price'>
-            <span>99999999円<br>(税込み)</span>
-            <div class='star-btn'>
-              <%= image_tag "star.png", class:"star-icon" %>
-              <span class='star-count'>0</span>
-            </div>
-          </div>
-        </div>
-        <% end %>
-      </li>
-      <%# //商品がある場合は表示されないようにしましょう %>
-      <%# //商品がない場合は以下のダミー商品が表示されるようにしましょう %>
     </ul>
   </div>
   <%# /商品一覧 %>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -128,11 +128,15 @@
     </div>
     <ul class='item-lists'>
 
+
+
+
+
       <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
       <li class='list'>
         <%= link_to "#" do %>
         <div class='item-img-content'>
-          <%= image_tag "item-sample.png", class: "item-img" %>
+          <%= image_tag ''.image, class: "item-img" %>
 
           <%# 商品が売れていればsold outを表示しましょう %>
           <div class='sold-out'>

--- a/db/migrate/20211002054157_create_buys.rb
+++ b/db/migrate/20211002054157_create_buys.rb
@@ -1,0 +1,9 @@
+class CreateBuys < ActiveRecord::Migration[6.0]
+  def change
+    create_table :buys do |t|
+      t.references :item, null: false, foreign_key: true
+      t.references :user, null: false, foreign_key: true
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_09_25_043303) do
+ActiveRecord::Schema.define(version: 2021_10_02_054157) do
 
   create_table "active_storage_attachments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name", null: false
@@ -31,6 +31,15 @@ ActiveRecord::Schema.define(version: 2021_09_25_043303) do
     t.string "checksum", null: false
     t.datetime "created_at", null: false
     t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
+  end
+
+  create_table "buys", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.bigint "item_id", null: false
+    t.bigint "user_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["item_id"], name: "index_buys_on_item_id"
+    t.index ["user_id"], name: "index_buys_on_user_id"
   end
 
   create_table "items", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
@@ -67,5 +76,7 @@ ActiveRecord::Schema.define(version: 2021_09_25_043303) do
   end
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "buys", "items"
+  add_foreign_key "buys", "users"
   add_foreign_key "items", "users"
 end

--- a/spec/factories/buys.rb
+++ b/spec/factories/buys.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :buy do
+    
+  end
+end

--- a/spec/factories/buys.rb
+++ b/spec/factories/buys.rb
@@ -1,5 +1,4 @@
 FactoryBot.define do
   factory :buy do
-    
   end
 end

--- a/spec/factories/items.rb
+++ b/spec/factories/items.rb
@@ -1,21 +1,20 @@
 FactoryBot.define do
   factory :item do
-    name          { Faker::Name.name}
-    explain       { Faker::Lorem.sentence}
+    name          { Faker::Name.name }
+    explain       { Faker::Lorem.sentence }
     category_id   { Faker::Number.between(from: 2, to: 11) }
     status_id     { Faker::Number.between(from: 2, to:  7) }
     postage_id    { Faker::Number.between(from: 2, to:  3) }
     prefecture_id { Faker::Number.between(from: 2, to: 48) }
-    take_days_id  { Faker::Number.between(from: 2, to:  4) }
-    price         { Faker::Number.between(from: 300, to: 9999999) }
+    take_days_id  { Faker::Number.between(from: 2, to: 4) }
+    price         { Faker::Number.between(from: 300, to: 9_999_999) }
 
-    #ダミーデータの生成に合わせてユーザ‐を生成する
+    # ダミーデータの生成に合わせてユーザ‐を生成する
     association :user
 
-    #生成するダミーデータに画像'public/images/test_image.png'を添付
+    # 生成するダミーデータに画像'public/images/test_image.png'を添付
     after(:build) do |item|
       item.image.attach(io: File.open('public/images/test_image.png'), filename: 'test_image.png')
     end
-
   end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -3,11 +3,11 @@ FactoryBot.define do
     transient do
       person { Gimei.name }
     end
-    nickname {Faker::Name.name}
-    email {Faker::Internet.free_email}
+    nickname { Faker::Name.name }
+    email { Faker::Internet.free_email }
     password = 'a1' + Faker::Internet.password(min_length: 6)
-    password {password}
-    password_confirmation {password}
+    password { password }
+    password_confirmation { password }
     first_name { person.first.kanji }
     last_name { person.last.kanji }
     first_name_kana { person.first.katakana }

--- a/spec/models/buy_spec.rb
+++ b/spec/models/buy_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Buy, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Item, type: :model do
         expect(@item).to be_valid
       end
       it '価格(price)が¥9,999,999以以下であれば保存できる' do
-        @item.price = 9999999
+        @item.price = 9_999_999
         expect(@item).to be_valid
       end
     end
@@ -68,22 +68,22 @@ RSpec.describe Item, type: :model do
       it '価格(price)が¥300未満では保存できない' do
         @item.price = 299
         @item.valid?
-        expect(@item.errors.full_messages).to include "Price は、半角数字で¥300~¥9,999,999の間で入力して下さい"
+        expect(@item.errors.full_messages).to include 'Price は、半角数字で¥300~¥9,999,999の間で入力して下さい'
       end
       it '価格(price)が¥9,999,999を超えると保存できない' do
-        @item.price = 10000000
+        @item.price = 10_000_000
         @item.valid?
-        expect(@item.errors.full_messages).to include "Price は、半角数字で¥300~¥9,999,999の間で入力して下さい"
+        expect(@item.errors.full_messages).to include 'Price は、半角数字で¥300~¥9,999,999の間で入力して下さい'
       end
       it '価格(price)が全角入力だと保存できない' do
         @item.price = '３００'
         @item.valid?
-        expect(@item.errors.full_messages).to include "Price は、半角数字で¥300~¥9,999,999の間で入力して下さい"
+        expect(@item.errors.full_messages).to include 'Price は、半角数字で¥300~¥9,999,999の間で入力して下さい'
       end
       it 'userが紐づいていないと保存できない。' do
         @item.user = nil
         @item.valid?
-        expect(@item.errors.full_messages).to include "User must exist"
+        expect(@item.errors.full_messages).to include 'User must exist'
       end
     end
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -4,114 +4,113 @@ RSpec.describe User, type: :model do
     @user = FactoryBot.build(:user)
   end
 
-  describe "ユーザー新規登録" do
+  describe 'ユーザー新規登録' do
     it 'nicknameとemail、password、password_confirmationと本人情報確認が存在すれば登録できる' do
       expect(@user).to be_valid
     end
-    it "nicknameが空だと登録できない" do
+    it 'nicknameが空だと登録できない' do
       @user.nickname = ''
       @user.valid?
       expect(@user.errors.full_messages).to include "Nickname can't be blank"
     end
-    it "emailが空では登録できない" do
+    it 'emailが空では登録できない' do
       @user.email = ''
       @user.valid?
       expect(@user.errors.full_messages).to include "Email can't be blank"
     end
-    it "emailが値が一意でないとは登録できない" do
+    it 'emailが値が一意でないとは登録できない' do
       @user.save
       another_user = FactoryBot.build(:user)
       another_user.email = @user.email
       another_user.valid?
       expect(another_user.errors.full_messages).to include 'Email has already been taken'
     end
-    it "emailが値が@を含んでいないと登録できない" do
+    it 'emailが値が@を含んでいないと登録できない' do
       @user.email = 'test'
       @user.valid?
-      expect(@user.errors.full_messages).to include "Email is invalid"
+      expect(@user.errors.full_messages).to include 'Email is invalid'
     end
-    it "passwordが空では登録できない" do
+    it 'passwordが空では登録できない' do
       @user.password = ''
       @user.valid?
       expect(@user.errors.full_messages).to include "Password can't be blank"
     end
-    it "passwordが5文字以下では登録できない（6文字以上の入力が必要）" do
+    it 'passwordが5文字以下では登録できない（6文字以上の入力が必要）' do
       @user.password = '123ab'
       @user.password_confirmation = @user.password
       @user.valid?
       expect(@user.errors.full_messages).to include 'Password is too short (minimum is 6 characters)'
     end
-    it "passwordが半角英数字混合でないと登録できない(数字のみ)" do
+    it 'passwordが半角英数字混合でないと登録できない(数字のみ)' do
       @user.password = '123456'
       @user.password_confirmation = @user.password
       @user.valid?
       expect(@user.errors.full_messages).to include 'Password には英字と数字の両方を含めて設定してください'
     end
-    it "passwordが半角英数字混合でないと登録できない(英字のみ)" do
+    it 'passwordが半角英数字混合でないと登録できない(英字のみ)' do
       @user.password = 'abcdef'
       @user.password_confirmation = @user.password
       @user.valid?
       expect(@user.errors.full_messages).to include 'Password には英字と数字の両方を含めて設定してください'
     end
-    it "全角文字を含むパスワードでは登録できない" do
+    it '全角文字を含むパスワードでは登録できない' do
       @user.password = 'あ123ab'
       @user.password_confirmation = @user.password
       @user.valid?
       expect(@user.errors.full_messages).to include 'Password には英字と数字の両方を含めて設定してください'
     end
-    it "passwordとpassword_confiremationの値が一致していないと登録できない" do
+    it 'passwordとpassword_confiremationの値が一致していないと登録できない' do
       @user.password = '123abc'
       @user.valid?
       expect(@user.errors.full_messages).to include "Password confirmation doesn't match Password"
     end
   end
 
-  describe "ユーザー本人情報確認" do
-    it "お名前(全角)の名前が空では登録できない" do
+  describe 'ユーザー本人情報確認' do
+    it 'お名前(全角)の名前が空では登録できない' do
       @user.first_name = ''
       @user.valid?
       expect(@user.errors.full_messages).to include "First name can't be blank"
     end
-    it "お名前(全角)の名字が空では登録できない" do
+    it 'お名前(全角)の名字が空では登録できない' do
       @user.last_name = ''
       @user.valid?
       expect(@user.errors.full_messages).to include "Last name can't be blank"
     end
-    it "お名前(全角)の名前が全角（漢字・ひらがな・カタカナ）以外を含むと登録できない" do
+    it 'お名前(全角)の名前が全角（漢字・ひらがな・カタカナ）以外を含むと登録できない' do
       @user.first_name = 'abc'
       @user.valid?
-      expect(@user.errors.full_messages).to include "First name には全角文字を使用してください"
+      expect(@user.errors.full_messages).to include 'First name には全角文字を使用してください'
     end
-    it "お名前(全角)の名字が全角（漢字・ひらがな・カタカナ）以外を含むと登録できない" do
+    it 'お名前(全角)の名字が全角（漢字・ひらがな・カタカナ）以外を含むと登録できない' do
       @user.last_name = 'abc'
       @user.valid?
-      expect(@user.errors.full_messages).to include "Last name には全角文字を使用してください"
+      expect(@user.errors.full_messages).to include 'Last name には全角文字を使用してください'
     end
-    it "お名前カナ(全角)の名前が空では登録できない" do
+    it 'お名前カナ(全角)の名前が空では登録できない' do
       @user.first_name_kana = ''
       @user.valid?
       expect(@user.errors.full_messages).to include "First name kana can't be blank"
     end
-    it "お名前カナ(全角)の名字が空では登録できない" do
+    it 'お名前カナ(全角)の名字が空では登録できない' do
       @user.last_name_kana = ''
       @user.valid?
       expect(@user.errors.full_messages).to include "Last name kana can't be blank"
     end
-    it "お名前(全角)の名前が全角（カタカナ）以外を含むと登録できない" do
+    it 'お名前(全角)の名前が全角（カタカナ）以外を含むと登録できない' do
       @user.first_name_kana = 'abc'
       @user.valid?
-      expect(@user.errors.full_messages).to include "First name kana には全角カナを使用してください"
+      expect(@user.errors.full_messages).to include 'First name kana には全角カナを使用してください'
     end
-    it "お名前(全角)の名字が全角（カタカナ）以外を含むと登録できない" do
+    it 'お名前(全角)の名字が全角（カタカナ）以外を含むと登録できない' do
       @user.last_name_kana = 'abc'
       @user.valid?
-      expect(@user.errors.full_messages).to include "Last name kana には全角カナを使用してください"
+      expect(@user.errors.full_messages).to include 'Last name kana には全角カナを使用してください'
     end
-    it "生年月日が空では登録できない" do
+    it '生年月日が空では登録できない' do
       @user.birthday = ''
       @user.valid?
       expect(@user.errors.full_messages).to include "Birthday can't be blank"
     end
   end
-
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 ENV['RAILS_ENV'] ||= 'test'
 require File.expand_path('../config/environment', __dir__)
 # Prevent database truncation if the environment is production
-abort("The Rails environment is running in production mode!") if Rails.env.production?
+abort('The Rails environment is running in production mode!') if Rails.env.production?
 require 'rspec/rails'
 # Add additional requires below this line. Rails is not loaded until this point!
 
@@ -31,7 +31,7 @@ rescue ActiveRecord::PendingMigrationError => e
   exit 1
 end
 
-I18n.locale = "en"
+I18n.locale = 'en'
 
 RSpec.configure do |config|
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -44,53 +44,51 @@ RSpec.configure do |config|
   # triggering implicit auto-inclusion in groups with matching metadata.
   config.shared_context_metadata_behavior = :apply_to_host_groups
 
-# The settings below are suggested to provide a good initial experience
-# with RSpec, but feel free to customize to your heart's content.
-=begin
-  # This allows you to limit a spec run to individual examples or groups
-  # you care about by tagging them with `:focus` metadata. When nothing
-  # is tagged with `:focus`, all examples get run. RSpec also provides
-  # aliases for `it`, `describe`, and `context` that include `:focus`
-  # metadata: `fit`, `fdescribe` and `fcontext`, respectively.
-  config.filter_run_when_matching :focus
-
-  # Allows RSpec to persist some state between runs in order to support
-  # the `--only-failures` and `--next-failure` CLI options. We recommend
-  # you configure your source control system to ignore this file.
-  config.example_status_persistence_file_path = "spec/examples.txt"
-
-  # Limits the available syntax to the non-monkey patched syntax that is
-  # recommended. For more details, see:
-  #   - http://rspec.info/blog/2012/06/rspecs-new-expectation-syntax/
-  #   - http://www.teaisaweso.me/blog/2013/05/27/rspecs-new-message-expectation-syntax/
-  #   - http://rspec.info/blog/2014/05/notable-changes-in-rspec-3/#zero-monkey-patching-mode
-  config.disable_monkey_patching!
-
-  # Many RSpec users commonly either run the entire suite or an individual
-  # file, and it's useful to allow more verbose output when running an
-  # individual spec file.
-  if config.files_to_run.one?
-    # Use the documentation formatter for detailed output,
-    # unless a formatter has already been configured
-    # (e.g. via a command-line flag).
-    config.default_formatter = "doc"
-  end
-
-  # Print the 10 slowest examples and example groups at the
-  # end of the spec run, to help surface which specs are running
-  # particularly slow.
-  config.profile_examples = 10
-
-  # Run specs in random order to surface order dependencies. If you find an
-  # order dependency and want to debug it, you can fix the order by providing
-  # the seed, which is printed after each run.
-  #     --seed 1234
-  config.order = :random
-
-  # Seed global randomization in this process using the `--seed` CLI option.
-  # Setting this allows you to use `--seed` to deterministically reproduce
-  # test failures related to randomization by passing the same `--seed` value
-  # as the one that triggered the failure.
-  Kernel.srand config.seed
-=end
+  # The settings below are suggested to provide a good initial experience
+  # with RSpec, but feel free to customize to your heart's content.
+  #   # This allows you to limit a spec run to individual examples or groups
+  #   # you care about by tagging them with `:focus` metadata. When nothing
+  #   # is tagged with `:focus`, all examples get run. RSpec also provides
+  #   # aliases for `it`, `describe`, and `context` that include `:focus`
+  #   # metadata: `fit`, `fdescribe` and `fcontext`, respectively.
+  #   config.filter_run_when_matching :focus
+  #
+  #   # Allows RSpec to persist some state between runs in order to support
+  #   # the `--only-failures` and `--next-failure` CLI options. We recommend
+  #   # you configure your source control system to ignore this file.
+  #   config.example_status_persistence_file_path = "spec/examples.txt"
+  #
+  #   # Limits the available syntax to the non-monkey patched syntax that is
+  #   # recommended. For more details, see:
+  #   #   - http://rspec.info/blog/2012/06/rspecs-new-expectation-syntax/
+  #   #   - http://www.teaisaweso.me/blog/2013/05/27/rspecs-new-message-expectation-syntax/
+  #   #   - http://rspec.info/blog/2014/05/notable-changes-in-rspec-3/#zero-monkey-patching-mode
+  #   config.disable_monkey_patching!
+  #
+  #   # Many RSpec users commonly either run the entire suite or an individual
+  #   # file, and it's useful to allow more verbose output when running an
+  #   # individual spec file.
+  #   if config.files_to_run.one?
+  #     # Use the documentation formatter for detailed output,
+  #     # unless a formatter has already been configured
+  #     # (e.g. via a command-line flag).
+  #     config.default_formatter = "doc"
+  #   end
+  #
+  #   # Print the 10 slowest examples and example groups at the
+  #   # end of the spec run, to help surface which specs are running
+  #   # particularly slow.
+  #   config.profile_examples = 10
+  #
+  #   # Run specs in random order to surface order dependencies. If you find an
+  #   # order dependency and want to debug it, you can fix the order by providing
+  #   # the seed, which is printed after each run.
+  #   #     --seed 1234
+  #   config.order = :random
+  #
+  #   # Seed global randomization in this process using the `--seed` CLI option.
+  #   # Setting this allows you to use `--seed` to deterministically reproduce
+  #   # test failures related to randomization by passing the same `--seed` value
+  #   # as the one that triggered the failure.
+  #   Kernel.srand config.seed
 end

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -1,4 +1,4 @@
-require "test_helper"
+require 'test_helper'
 
 class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
   driven_by :selenium, using: :chrome, screen_size: [1400, 1400]

--- a/test/channels/application_cable/connection_test.rb
+++ b/test/channels/application_cable/connection_test.rb
@@ -1,4 +1,4 @@
-require "test_helper"
+require 'test_helper'
 
 class ApplicationCable::ConnectionTest < ActionCable::Connection::TestCase
   # test "connects with cookies" do


### PR DESCRIPTION
# what
‐ 商品一覧表示機能の実装
- 以下の実装条件は、商品購入機能実装前なので導入してません。
- |売却済みの商品は、画像上に「sold out」の文字が表示されること。

# why
‐ 商品を一覧表示する機能を実装するための諸所の機能を実装

# 確認におけるGazo参考ファイルのURL
　* 商品のデータがない場合は、ダミー商品が表示されている動画
　　https://gyazo.com/223bd33f22e1195f53426e0ef11785af
　* 商品のデータがある場合は、商品が一覧で表示されている動画
　　https://gyazo.com/3f2843198134eff21e932a4ef1090073

