### PR TITLE
商品詳細表示機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -20,6 +20,8 @@ class ItemsController < ApplicationController
 
   def show
     @item = Item.find(params[:id])
+  end
+  
   private
 
   def item_params

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -21,10 +21,11 @@ class ItemsController < ApplicationController
   def show
     @item = Item.find(params[:id])
   end
-  
+
   private
 
   def item_params
-    params.require(:item).permit(:image, :name, :explain, :category_id, :status_id, :postage_id, :prefecture_id, :take_days_id, :price).merge(user_id: current_user.id)
+    params.require(:item).permit(:image, :name, :explain, :category_id, :status_id, :postage_id, :prefecture_id, :take_days_id,
+                                 :price).merge(user_id: current_user.id)
   end
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -18,6 +18,8 @@ class ItemsController < ApplicationController
     end
   end
 
+  def show
+    @item = Item.find(params[:id])
   private
 
   def item_params

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -16,10 +16,8 @@ class Item < ApplicationRecord
   # バリデーション
   validates :image, :name, :explain, :price, presence: true
   validates :price,
-            numericality: { only_integer: true, greater_than_or_equal_to: 300, less_than_or_equal_to: 9_999_999,
-                            message: 'は、半角数字で¥300~¥9,999,999の間で入力して下さい' }
+            numericality: { only_integer: true, greater_than_or_equal_to: 300, less_than_or_equal_to: 9_999_999, message: 'は、半角数字で¥300~¥9,999,999の間で入力して下さい' }
 
   # Active Hashのバリデーション
-  validates :category_id, :status_id, :postage_id, :prefecture_id, :take_days_id, presence: true,
-                                                                                  numericality: { other_than: 1, message: "can't be blank" }
+  validates :category_id, :status_id, :postage_id, :prefecture_id, :take_days_id, presence: true, numericality: { other_than: 1, message: "can't be blank" }
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -16,8 +16,10 @@ class Item < ApplicationRecord
   # バリデーション
   validates :image, :name, :explain, :price, presence: true
   validates :price,
-            numericality: { only_integer: true, greater_than_or_equal_to: 300, less_than_or_equal_to: 9_999_999, message: 'は、半角数字で¥300~¥9,999,999の間で入力して下さい' }
+            numericality: { only_integer: true, greater_than_or_equal_to: 300, less_than_or_equal_to: 9_999_999,
+                            message: 'は、半角数字で¥300~¥9,999,999の間で入力して下さい' }
 
   # Active Hashのバリデーション
-  validates :category_id, :status_id, :postage_id, :prefecture_id, :take_days_id, presence: true, numericality: { other_than: 1, message: "can't be blank" }
+  validates :category_id, :status_id, :postage_id, :prefecture_id, :take_days_id, presence: true,
+                                                                                  numericality: { other_than: 1, message: "can't be blank" }
 end

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -132,7 +132,7 @@
         <%# if present?で商品のインスタンス変数itemsになにかしらの値入っている場合、表示される %>
         <% @items.each do |item| %>
         <li class='list'>
-          <%= link_to "#" do %>
+          <%= link_to item_path(item.id) do %>
           <div class='item-img-content'>
             <%= image_tag item.image, class: "item-img" %>
 

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -99,9 +99,7 @@
       後ろの商品 ＞
     </a>
   </div>
-  <%# 詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
-  <a href="#" class="another-item"><%= "商品のカテゴリー名" %>をもっと見る</a>
-  <%# //詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
+  <a href="#" class="another-item"><%= @item.category.name %>をもっと見る</a>
 </div>
 
 <%= render "shared/footer" %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -23,18 +23,15 @@
       </span>
     </div>
 
-    <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
-
-    <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
-    <p class="or-text">or</p>
-    <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
-
-    <%# 商品が売れていない場合はこちらを表示しましょう %>
-    <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
-    <%# //商品が売れていない場合はこちらを表示しましょう %>
-
-
-    <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
+    <%# ifでログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、表示される内容を分けている %>
+    <% if user_signed_in? && @item.user_id == current_user.id %>
+      <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
+      <p class="or-text">or</p>
+      <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
+    <% elsif user_signed_in? %>
+      <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
+    <% end %>
+    <%# ifでログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、表示される内容を分けている %>
 
     <div class="item-explain-box">
       <span><%= @item.explain %></span>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -4,10 +4,10 @@
 <div class="item-show">
   <div class="item-box">
     <h2 class="name">
-      <%= "商品名" %>
+      <%= @item.name %>
     </h2>
     <div class="item-img-content">
-      <%= image_tag "item-sample.png" ,class:"item-box-img" %>
+      <%= image_tag @item.image ,class:"item-box-img" %>
       <%# 商品が売れている場合は、sold outを表示しましょう %>
       <div class="sold-out">
         <span>Sold Out!!</span>
@@ -16,10 +16,10 @@
     </div>
     <div class="item-price-box">
       <span class="item-price">
-        ¥ 999,999,999
+        <%= @item.price %>円
       </span>
       <span class="item-postage">
-        <%= "配送料負担" %>
+        <%= @item.postage.name %>
       </span>
     </div>
 
@@ -37,33 +37,33 @@
     <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
 
     <div class="item-explain-box">
-      <span><%= "商品説明" %></span>
+      <span><%= @item.explain %></span>
     </div>
     <table class="detail-table">
       <tbody>
         <tr>
           <th class="detail-item">出品者</th>
-          <td class="detail-value"><%= "出品者名" %></td>
+          <td class="detail-value"><%= @item.user.nickname %></td>
         </tr>
         <tr>
           <th class="detail-item">カテゴリー</th>
-          <td class="detail-value"><%= "カテゴリー名" %></td>
+          <td class="detail-value"><%= @item.category.name %></td>
         </tr>
         <tr>
           <th class="detail-item">商品の状態</th>
-          <td class="detail-value"><%= "商品の状態" %></td>
+          <td class="detail-value"><%= @item.status.name %></td>
         </tr>
         <tr>
           <th class="detail-item">配送料の負担</th>
-          <td class="detail-value"><%= "発送料の負担" %></td>
+          <td class="detail-value"><%= @item.postage.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送元の地域</th>
-          <td class="detail-value"><%= "発送元の地域" %></td>
+          <td class="detail-value"><%= @item.prefecture.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送日の目安</th>
-          <td class="detail-value"><%= "発送日の目安" %></td>
+          <td class="detail-value"><%= @item.take_days.name %></td>
         </tr>
       </tbody>
     </table>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
   devise_for :users
   root to: "items#index"
-  resources :items, only: [:index, :new, :create ]
+  resources :items, only: [ :index, :new, :create, :show ]
 end


### PR DESCRIPTION
# what
‐‐ 商品詳細表示機能の実装
** 現段階では、商品購入機能の実装が済んでいないため、売却済みによる判定は実装しておりません。

# why
‐‐ 出品されている商品の詳細を表示する機能を実装するための諸所の機能を実装

確認におけるGazo参考ファイルのURL
　* ログイン状態且つ、自身が出品した販売中商品の商品詳細ページへ遷移した動画
　　https://gyazo.com/e4562c46c92f6373736983386f7a8d78
　* ログイン状態且つ、自身が出品していない販売中商品の商品詳細ページへ遷移した動画
　　https://gyazo.com/207fc1a851bfbf1a41cf5b496e747684
　* ログアウト状態で、商品詳細ページへ遷移した動画
　　https://gyazo.com/756877ceb934b7f4f0321f03d3635e06
